### PR TITLE
Add Initial Project Layout

### DIFF
--- a/Scenes/Game Scenes/00_main_menu.tscn
+++ b/Scenes/Game Scenes/00_main_menu.tscn
@@ -1,0 +1,45 @@
+[gd_scene load_steps=2 format=3 uid="uid://bff7j1pbmewsu"]
+
+[ext_resource type="Script" uid="uid://byyoc0qbtrsq3" path="res://Scripts/main_menu.gd" id="1_1qbve"]
+
+[node name="Main Menu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_1qbve")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -46.0
+offset_top = -50.5
+offset_right = 46.0
+offset_bottom = 50.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="Play" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Play"
+
+[node name="Options" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Options"
+
+[node name="Quit Game" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Quit Game"
+
+[connection signal="pressed" from="MarginContainer/VBoxContainer/Play" to="." method="_on_play_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/Options" to="." method="_on_options_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/Quit Game" to="." method="_on_quit_game_pressed"]

--- a/Scenes/Game Scenes/00_options_menu.tscn
+++ b/Scenes/Game Scenes/00_options_menu.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=2 format=3 uid="uid://blnr0wvkv4sr8"]
+
+[ext_resource type="Script" uid="uid://bsfsxsb3mipyh" path="res://Scripts/00_options_menu.gd" id="1_wi8c1"]
+
+[node name="Main Menu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_wi8c1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -33.5
+offset_top = -33.0
+offset_right = 33.5
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="Volume" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Volume"
+
+[node name="Back" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Back"
+
+[connection signal="pressed" from="MarginContainer/VBoxContainer/Volume" to="." method="_on_volume_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/Back" to="." method="_on_back_pressed"]

--- a/Scenes/Game Scenes/01_loop_start.tscn
+++ b/Scenes/Game Scenes/01_loop_start.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://c3joe3osepg4w"]
+
+[node name="Loop Start" type="Node2D"]
+
+[node name="Polygon2D" type="Polygon2D" parent="."]
+polygon = PackedVector2Array(226, 73, 226, 256, 474, 283, 630, 167, 488, 64)

--- a/Scripts/00_options_menu.gd
+++ b/Scripts/00_options_menu.gd
@@ -1,0 +1,10 @@
+extends Control
+
+
+func _on_volume_pressed() -> void:
+	pass # Replace with function body.
+
+
+func _on_back_pressed() -> void:
+	get_tree().change_scene_to_file("res://Scenes/Game Scenes/00_main_menu.tscn")
+	pass # Replace with function body.

--- a/Scripts/00_options_menu.gd.uid
+++ b/Scripts/00_options_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://bsfsxsb3mipyh

--- a/Scripts/main_menu.gd
+++ b/Scripts/main_menu.gd
@@ -1,0 +1,17 @@
+extends Control
+
+
+
+func _on_play_pressed() -> void:
+	get_tree().change_scene_to_file("res://Scenes/Game Scenes/01_loop_start.tscn")
+	pass # Replace with function body.
+
+
+func _on_options_pressed() -> void:
+	get_tree().change_scene_to_file("res://Scenes/Game Scenes/00_options_menu.tscn")
+	pass # Replace with function body.
+
+
+func _on_quit_game_pressed() -> void: # Quit the game
+	get_tree().quit()
+	pass # Replace with function body.

--- a/Scripts/main_menu.gd.uid
+++ b/Scripts/main_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://byyoc0qbtrsq3

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -1,0 +1,108 @@
+[preset.0]
+
+name="Linux"
+platform="Linux"
+runnable=true
+advanced_options=false
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="./Seconds of Eternity.x86_64"
+patches=PackedStringArray()
+encryption_include_filters=""
+encryption_exclude_filters=""
+seed=0
+encrypt_pck=false
+encrypt_directory=false
+script_export_mode=2
+
+[preset.0.options]
+
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_wrapper=1
+binary_format/embed_pck=false
+texture_format/s3tc_bptc=true
+texture_format/etc2_astc=false
+binary_format/architecture="x86_64"
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="#!/usr/bin/env bash
+export DISPLAY=:0
+unzip -o -q \"{temp_dir}/{archive_name}\" -d \"{temp_dir}\"
+\"{temp_dir}/{exe_name}\" {cmd_args}"
+ssh_remote_deploy/cleanup_script="#!/usr/bin/env bash
+kill $(pgrep -x -f \"{temp_dir}/{exe_name} {cmd_args}\")
+rm -rf \"{temp_dir}\""
+
+[preset.1]
+
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=true
+advanced_options=false
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="./Seconds of Eternity.exe"
+patches=PackedStringArray()
+encryption_include_filters=""
+encryption_exclude_filters=""
+seed=0
+encrypt_pck=false
+encrypt_directory=false
+script_export_mode=2
+
+[preset.1.options]
+
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_wrapper=1
+binary_format/embed_pck=false
+texture_format/s3tc_bptc=true
+texture_format/etc2_astc=false
+binary_format/architecture="x86_64"
+codesign/enable=false
+codesign/timestamp=true
+codesign/timestamp_server_url=""
+codesign/digest_algorithm=1
+codesign/description=""
+codesign/custom_options=PackedStringArray()
+application/modify_resources=true
+application/icon=""
+application/console_wrapper_icon=""
+application/icon_interpolation=4
+application/file_version=""
+application/product_version=""
+application/company_name=""
+application/product_name=""
+application/file_description=""
+application/copyright=""
+application/trademarks=""
+application/export_angle=0
+application/export_d3d12=0
+application/d3d12_agility_sdk_multiarch=true
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="Expand-Archive -LiteralPath '{temp_dir}\\{archive_name}' -DestinationPath '{temp_dir}'
+$action = New-ScheduledTaskAction -Execute '{temp_dir}\\{exe_name}' -Argument '{cmd_args}'
+$trigger = New-ScheduledTaskTrigger -Once -At 00:00
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings
+Register-ScheduledTask godot_remote_debug -InputObject $task -Force:$true
+Start-ScheduledTask -TaskName godot_remote_debug
+while (Get-ScheduledTask -TaskName godot_remote_debug | ? State -eq running) { Start-Sleep -Milliseconds 100 }
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue"
+ssh_remote_deploy/cleanup_script="Stop-ScheduledTask -TaskName godot_remote_debug -ErrorAction:SilentlyContinue
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue
+Remove-Item -Recurse -Force '{temp_dir}'"

--- a/project.godot
+++ b/project.godot
@@ -11,5 +11,11 @@ config_version=5
 [application]
 
 config/name="Project Loop"
+run/main_scene="uid://bff7j1pbmewsu"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
+
+[display]
+
+window/size/viewport_width=1280
+window/size/viewport_height=800

--- a/project.godot
+++ b/project.godot
@@ -11,6 +11,7 @@ config_version=5
 [application]
 
 config/name="Project Loop"
+config/version="0.0.1-SNAPSHOT"
 run/main_scene="uid://bff7j1pbmewsu"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"


### PR DESCRIPTION
To keep the project organized in a sane and logical way, I've introduced the base skeleton layout as well as some menu scenes:
<img width="1294" height="877" alt="image" src="https://github.com/user-attachments/assets/2c60a474-1e5a-44d1-b705-0d27caa28ed3" />
<img width="1294" height="877" alt="image" src="https://github.com/user-attachments/assets/d55cc591-44b7-4d95-ab7e-eb8e0ddbe099" />
<img width="1294" height="877" alt="image" src="https://github.com/user-attachments/assets/39b52db0-a825-40d7-85e4-b0b709c562af" />
This is all primarily to shell out how the project itself should remain structured so that we can keep track of everything:
<img width="439" height="597" alt="image" src="https://github.com/user-attachments/assets/467b2594-ef83-4dec-a804-61d99f913f0c" />


