### PR TITLE
Add battery bar

### DIFF
--- a/Scenes/Game Scenes/01_loop_start.tscn
+++ b/Scenes/Game Scenes/01_loop_start.tscn
@@ -23,6 +23,10 @@ size = Vector2(38, 50)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_frnmx"]
 bg_color = Color(0.0909465, 0.726227, 0, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_r33d5"]
 texture = ExtResource("11_gfa55")

--- a/Scenes/Game Scenes/01_loop_start.tscn
+++ b/Scenes/Game Scenes/01_loop_start.tscn
@@ -1002,7 +1002,7 @@ destination_door_tag = "To_Scene_1"
 spawn_direction = "left"
 
 [node name="CollisionShape2D" parent="Doors/Door_To_Scene_2" index="0"]
-position = Vector2(58, -120)
+position = Vector2(57, -62)
 
 [node name="Spawn" parent="Doors/Door_To_Scene_2" index="1"]
 position = Vector2(-38, 0)

--- a/Scenes/Game Scenes/01_loop_start.tscn
+++ b/Scenes/Game Scenes/01_loop_start.tscn
@@ -789,7 +789,7 @@ polygon = PackedVector2Array(1, 3, 165, 3, 162, 26, 6, 25)
 polygon = PackedVector2Array(1, 3, 6, 25, 162, 26, 165, 3)
 
 [node name="Player" type="CharacterBody2D" parent="."]
-position = Vector2(2371, 642)
+position = Vector2(-2697, 674)
 script = ExtResource("1_a0a4o")
 
 [node name="RobyV01" type="Sprite2D" parent="Player"]
@@ -1002,10 +1002,10 @@ destination_door_tag = "To_Scene_1"
 spawn_direction = "left"
 
 [node name="CollisionShape2D" parent="Doors/Door_To_Scene_2" index="0"]
-position = Vector2(57, -51)
+position = Vector2(58, -120)
 
 [node name="Spawn" parent="Doors/Door_To_Scene_2" index="1"]
-position = Vector2(0, -35)
+position = Vector2(-38, 0)
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 script = ExtResource("8_qp2oi")

--- a/Scenes/Game Scenes/01_loop_start.tscn
+++ b/Scenes/Game Scenes/01_loop_start.tscn
@@ -1050,7 +1050,7 @@ offset_left = -600.0
 offset_bottom = 40.0
 grow_horizontal = 0
 
-[node name="ProgressBar" type="ProgressBar" parent="CanvasLayer/Control/LifeBarPanel"]
+[node name="Battery" type="ProgressBar" parent="CanvasLayer/Control/LifeBarPanel"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5

--- a/Scenes/Game Scenes/01_loop_start.tscn
+++ b/Scenes/Game Scenes/01_loop_start.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=32 format=4 uid="uid://c3joe3osepg4w"]
+[gd_scene load_steps=33 format=4 uid="uid://c3joe3osepg4w"]
 
 [ext_resource type="Script" uid="uid://mtv4jj62dn53" path="res://Scripts/player.gd" id="1_a0a4o"]
 [ext_resource type="Texture2D" uid="uid://btybe5jdv2mmp" path="res://Assets/Compressed Assets/Roby v01.png" id="1_gbtja"]
@@ -20,6 +20,9 @@ viewport_path = NodePath("Bolts/3D Bolt Texture")
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_g20h4"]
 size = Vector2(38, 50)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_frnmx"]
+bg_color = Color(0.0909465, 0.726227, 0, 1)
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_r33d5"]
 texture = ExtResource("11_gfa55")
@@ -1051,18 +1054,20 @@ offset_bottom = 40.0
 grow_horizontal = 0
 
 [node name="Battery" type="ProgressBar" parent="CanvasLayer/Control/LifeBarPanel"]
+layout_direction = 2
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -2.0
+offset_left = -285.0
 offset_top = -13.5
-offset_right = 2.0
+offset_right = 285.0
 offset_bottom = 13.5
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_styles/fill = SubResource("StyleBoxFlat_frnmx")
 step = 0.001
 value = 100.0
 

--- a/Scenes/Game Scenes/01_loop_start.tscn
+++ b/Scenes/Game Scenes/01_loop_start.tscn
@@ -1012,27 +1012,62 @@ script = ExtResource("8_qp2oi")
 
 [node name="Control" type="Control" parent="CanvasLayer"]
 layout_mode = 3
-anchors_preset = 0
-offset_right = 256.0
-offset_bottom = 40.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
 metadata/_edit_use_anchors_ = true
 
 [node name="Panel" type="Panel" parent="CanvasLayer/Control"]
-layout_mode = 0
+layout_mode = 1
 offset_right = 256.0
 offset_bottom = 40.0
-metadata/_edit_use_anchors_ = true
 
 [node name="Score" type="RichTextLabel" parent="CanvasLayer/Control/Panel"]
-layout_mode = 0
-offset_right = 256.0
-offset_bottom = 40.0
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -128.0
+offset_top = -20.0
+offset_right = 128.0
+offset_bottom = 20.0
+grow_horizontal = 2
+grow_vertical = 2
 bbcode_enabled = true
-metadata/_edit_use_anchors_ = true
+
+[node name="LifeBarPanel" type="Panel" parent="CanvasLayer/Control"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -600.0
+offset_bottom = 40.0
+grow_horizontal = 0
+
+[node name="ProgressBar" type="ProgressBar" parent="CanvasLayer/Control/LifeBarPanel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -2.0
+offset_top = -13.5
+offset_right = 2.0
+offset_bottom = 13.5
+grow_horizontal = 2
+grow_vertical = 2
+step = 0.001
+value = 100.0
 
 [node name="ParallaxBackground" type="ParallaxBackground" parent="."]
+visible = false
 
 [node name="LowerRocks" type="ParallaxLayer" parent="ParallaxBackground"]
 position = Vector2(595, -36)
@@ -1191,6 +1226,7 @@ region_enabled = true
 region_rect = Rect2(0, 0, 960, 228.5)
 
 [node name="ParallaxBackground2" type="ParallaxBackground" parent="."]
+visible = false
 offset = Vector2(-2278, 0)
 transform = Transform2D(1, 0, 0, 1, -2278, 0)
 

--- a/Scenes/Game Scenes/02_first_level.tscn
+++ b/Scenes/Game Scenes/02_first_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://ism3awfblpva"]
+[gd_scene load_steps=18 format=3 uid="uid://ism3awfblpva"]
 
 [ext_resource type="Script" uid="uid://mtv4jj62dn53" path="res://Scripts/player.gd" id="1_d1fgf"]
 [ext_resource type="Script" uid="uid://db62k5uafayjq" path="res://Scripts/02_first_level.gd" id="1_vmrgu"]
@@ -11,6 +11,9 @@
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_4pfj8"]
 
 [sub_resource type="Curve2D" id="Curve2D_vmrgu"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4pfj8"]
+bg_color = Color(0.0909465, 0.726227, 0, 1)
 
 [sub_resource type="Curve2D" id="Curve2D_o70yu"]
 _data = {
@@ -238,18 +241,20 @@ offset_bottom = 40.0
 grow_horizontal = 0
 
 [node name="Battery" type="ProgressBar" parent="CanvasLayer/Control/LifeBarPanel"]
+layout_direction = 2
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -2.0
+offset_left = -285.0
 offset_top = -13.5
-offset_right = 2.0
+offset_right = 285.0
 offset_bottom = 13.5
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_styles/fill = SubResource("StyleBoxFlat_4pfj8")
 step = 0.001
 value = 100.0
 

--- a/Scenes/Game Scenes/02_first_level.tscn
+++ b/Scenes/Game Scenes/02_first_level.tscn
@@ -14,6 +14,10 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4pfj8"]
 bg_color = Color(0.0909465, 0.726227, 0, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
 
 [sub_resource type="Curve2D" id="Curve2D_o70yu"]
 _data = {

--- a/Scenes/Game Scenes/02_first_level.tscn
+++ b/Scenes/Game Scenes/02_first_level.tscn
@@ -199,23 +199,59 @@ script = ExtResource("6_o70yu")
 
 [node name="Control" type="Control" parent="CanvasLayer"]
 layout_mode = 3
-anchors_preset = 0
-offset_right = 256.0
-offset_bottom = 40.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
 metadata/_edit_use_anchors_ = true
 
 [node name="Panel" type="Panel" parent="CanvasLayer/Control"]
-layout_mode = 0
+layout_mode = 1
 offset_right = 256.0
 offset_bottom = 40.0
 
 [node name="Score" type="RichTextLabel" parent="CanvasLayer/Control/Panel"]
-layout_mode = 0
-offset_right = 256.0
-offset_bottom = 40.0
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -128.0
+offset_top = -20.0
+offset_right = 128.0
+offset_bottom = 20.0
+grow_horizontal = 2
+grow_vertical = 2
 bbcode_enabled = true
+
+[node name="LifeBarPanel" type="Panel" parent="CanvasLayer/Control"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -600.0
+offset_bottom = 40.0
+grow_horizontal = 0
+
+[node name="Battery" type="ProgressBar" parent="CanvasLayer/Control/LifeBarPanel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -2.0
+offset_top = -13.5
+offset_right = 2.0
+offset_bottom = 13.5
+grow_horizontal = 2
+grow_vertical = 2
+step = 0.001
+value = 100.0
 
 [node name="Moving Platform" type="Path2D" parent="."]
 position = Vector2(631, 562)

--- a/Scenes/Game Scenes/LevelTest.tscn
+++ b/Scenes/Game Scenes/LevelTest.tscn
@@ -1673,6 +1673,10 @@ sources/4 = SubResource("TileSetAtlasSource_8dxgu")
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jirwo"]
 bg_color = Color(0.0909465, 0.726227, 0, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
 
 [sub_resource type="ViewportTexture" id="ViewportTexture_jirwo"]
 viewport_path = NodePath("3D Bolt Texture")

--- a/Scenes/Game Scenes/LevelTest.tscn
+++ b/Scenes/Game Scenes/LevelTest.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=4 uid="uid://cn5n77mcy1jib"]
+[gd_scene load_steps=25 format=4 uid="uid://cn5n77mcy1jib"]
 
 [ext_resource type="Script" uid="uid://mtv4jj62dn53" path="res://Scripts/player.gd" id="1_r7f2y"]
 [ext_resource type="Script" path="res://Scenes/Game Scenes/level_test.gd" id="1_ug50a"]
@@ -1671,6 +1671,9 @@ sources/2 = SubResource("TileSetAtlasSource_y8c61")
 sources/3 = SubResource("TileSetAtlasSource_g414q")
 sources/4 = SubResource("TileSetAtlasSource_8dxgu")
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jirwo"]
+bg_color = Color(0.0909465, 0.726227, 0, 1)
+
 [sub_resource type="ViewportTexture" id="ViewportTexture_jirwo"]
 viewport_path = NodePath("3D Bolt Texture")
 
@@ -1773,18 +1776,20 @@ offset_bottom = 40.0
 grow_horizontal = 0
 
 [node name="Battery" type="ProgressBar" parent="CanvasLayer/Control/LifeBarPanel"]
+layout_direction = 2
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -2.0
+offset_left = -285.0
 offset_top = -13.5
-offset_right = 2.0
+offset_right = 285.0
 offset_bottom = 13.5
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_styles/fill = SubResource("StyleBoxFlat_jirwo")
 step = 0.001
 value = 100.0
 

--- a/Scenes/Game Scenes/LevelTest.tscn
+++ b/Scenes/Game Scenes/LevelTest.tscn
@@ -1734,27 +1734,59 @@ script = ExtResource("7_nvme5")
 
 [node name="Control" type="Control" parent="CanvasLayer"]
 layout_mode = 3
-anchors_preset = 0
-offset_right = 256.0
-offset_bottom = 40.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
 metadata/_edit_use_anchors_ = true
-metadata/_edit_lock_ = true
 
 [node name="Panel" type="Panel" parent="CanvasLayer/Control"]
-layout_mode = 0
+layout_mode = 1
 offset_right = 256.0
 offset_bottom = 40.0
-metadata/_edit_use_anchors_ = true
-metadata/_edit_lock_ = true
 
 [node name="Score" type="RichTextLabel" parent="CanvasLayer/Control/Panel"]
-layout_mode = 0
-offset_right = 256.0
-offset_bottom = 40.0
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -128.0
+offset_top = -20.0
+offset_right = 128.0
+offset_bottom = 20.0
+grow_horizontal = 2
+grow_vertical = 2
 bbcode_enabled = true
-metadata/_edit_use_anchors_ = true
+
+[node name="LifeBarPanel" type="Panel" parent="CanvasLayer/Control"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -600.0
+offset_bottom = 40.0
+grow_horizontal = 0
+
+[node name="Battery" type="ProgressBar" parent="CanvasLayer/Control/LifeBarPanel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -2.0
+offset_top = -13.5
+offset_right = 2.0
+offset_bottom = 13.5
+grow_horizontal = 2
+grow_vertical = 2
+step = 0.001
+value = 100.0
 
 [node name="ParallaxBackground" type="ParallaxBackground" parent="."]
 

--- a/Scripts/ScoreManager.gd
+++ b/Scripts/ScoreManager.gd
@@ -3,8 +3,11 @@ extends Node
 const DEBUG_LOGS = false
 signal bolt_collected_global
 
-var score = 0
+var score : int = 0
+var health : float = 100.000000
+
 @onready var score_label = null  # You’ll set this from your UI
+@onready var battery_bar: ProgressBar = null
 
 func add_score(amount := 1):
 	score += amount

--- a/Scripts/UI.gd
+++ b/Scripts/UI.gd
@@ -11,7 +11,7 @@ func _ready() -> void:
 	battery_bar.value = ScoreManager.health
 	
 func _process(delta: float) -> void:
-	ScoreManager.health -= 0.00001
+	ScoreManager.health -= 0.00001 * delta
 	battery_bar.value = ScoreManager.health
 	Logger.log_debug("Battery bar value: %s" % battery_bar.value, DEBUG_LOG)
 	Logger.log_debug("ScoreManager.health value: %s" % ScoreManager.health, DEBUG_LOG)

--- a/Scripts/UI.gd
+++ b/Scripts/UI.gd
@@ -1,7 +1,17 @@
 extends CanvasLayer
 
+const DEBUG_LOG = true
+
 @onready var score_label: RichTextLabel = get_node("Control/Panel/Score")
+@onready var battery_bar: ProgressBar = get_node("Control/LifeBarPanel/Battery")
 
 func _ready() -> void:
 	ScoreManager.score_label = get_node("Control/Panel/Score")
 	score_label.text = "[center] Score: [color=yellow]%d[/color][/center]" % ScoreManager.score
+	battery_bar.value = ScoreManager.health
+	
+func _process(delta: float) -> void:
+	ScoreManager.health -= 0.00001
+	battery_bar.value = ScoreManager.health
+	Logger.log_debug("Battery bar value: %s" % battery_bar.value, DEBUG_LOG)
+	Logger.log_debug("ScoreManager.health value: %s" % ScoreManager.health, DEBUG_LOG)

--- a/Scripts/UI.gd
+++ b/Scripts/UI.gd
@@ -11,7 +11,7 @@ func _ready() -> void:
 	battery_bar.value = ScoreManager.health
 	
 func _process(delta: float) -> void:
-	ScoreManager.health -= 0.00001 * delta
+	ScoreManager.health -= 0.1 * delta
 	battery_bar.value = ScoreManager.health
 	Logger.log_debug("Battery bar value: %s" % battery_bar.value, DEBUG_LOG)
 	Logger.log_debug("ScoreManager.health value: %s" % ScoreManager.health, DEBUG_LOG)

--- a/Scripts/UI.gd
+++ b/Scripts/UI.gd
@@ -1,7 +1,7 @@
 extends CanvasLayer
 
-@onready var score_label = $Control/Panel/Score
+@onready var score_label: RichTextLabel = get_node("Control/Panel/Score")
 
 func _ready() -> void:
-	ScoreManager.score_label = $Control/Panel/Score
+	ScoreManager.score_label = get_node("Control/Panel/Score")
 	score_label.text = "[center] Score: [color=yellow]%d[/color][/center]" % ScoreManager.score


### PR DESCRIPTION
Part of the core gameplay is the fact that the battery bar will be decreasing overtime. This sets up the battery bar to be used via the global `ScoreManager.health` value. This way it can be tracked between scenes. For now as a placeholder, it's just a giant green bar with the percentage on it:
<img width="1307" height="890" alt="image" src="https://github.com/user-attachments/assets/eaab9066-7207-4ac0-85fe-4d5c0149ac74" />
