### PR TITLE
Add pause menu

### DIFF
--- a/Scenes/Game Scenes/01_loop_start.tscn
+++ b/Scenes/Game Scenes/01_loop_start.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=32 format=4 uid="uid://c3joe3osepg4w"]
+[gd_scene load_steps=33 format=4 uid="uid://c3joe3osepg4w"]
 
 [ext_resource type="Script" uid="uid://mtv4jj62dn53" path="res://Scripts/player.gd" id="1_a0a4o"]
 [ext_resource type="Texture2D" uid="uid://btybe5jdv2mmp" path="res://Assets/Compressed Assets/Roby v01.png" id="1_gbtja"]
@@ -14,6 +14,7 @@
 [ext_resource type="Texture2D" uid="uid://bfbslbfn4cla8" path="res://Assets/2D Assets/1_Industrial_Tileset_1B.png" id="12_doqbh"]
 [ext_resource type="Texture2D" uid="uid://jqlyi84lpwbt" path="res://Assets/2D Assets/1_Industrial_Tileset_1C.png" id="13_s7oi5"]
 [ext_resource type="Texture2D" uid="uid://o41sklbe1op8" path="res://Assets/Tilesets/spikes.png" id="14_frnmx"]
+[ext_resource type="PackedScene" uid="uid://u7xlfve1uxrm" path="res://Scenes/Game Scenes/pause_menu.tscn" id="15_0xv7n"]
 
 [sub_resource type="ViewportTexture" id="ViewportTexture_v16l4"]
 viewport_path = NodePath("Bolts/3D Bolt Texture")
@@ -1363,6 +1364,9 @@ polygon = PackedVector2Array(2802, 777, 2800, 473, 2925, 494, 2923, 779)
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Polygon2D2/StaticBody2D"]
 polygon = PackedVector2Array(2801, 777, 2801, 473, 2925, 494, 2923, 778)
 one_way_collision = true
+
+[node name="PauseMenu" parent="." instance=ExtResource("15_0xv7n")]
+visible = false
 
 [connection signal="input_event" from="Polygon2D/StaticBody2D" to="." method="_on_static_body_2d_input_event"]
 [connection signal="input_event" from="Polygon2D2/StaticBody2D" to="." method="_on_static_body_2d_input_event"]

--- a/Scenes/Game Scenes/02_first_level.tscn
+++ b/Scenes/Game Scenes/02_first_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://ism3awfblpva"]
+[gd_scene load_steps=18 format=3 uid="uid://ism3awfblpva"]
 
 [ext_resource type="Script" uid="uid://mtv4jj62dn53" path="res://Scripts/player.gd" id="1_d1fgf"]
 [ext_resource type="Script" uid="uid://db62k5uafayjq" path="res://Scripts/02_first_level.gd" id="1_vmrgu"]
@@ -6,7 +6,8 @@
 [ext_resource type="PackedScene" uid="uid://cx0k1lcljgqis" path="res://Scenes/Scene Assets/door.tscn" id="4_8f4wm"]
 [ext_resource type="Script" uid="uid://c3l0v8hb8wswj" path="res://Scripts/Bolt.gd" id="6_4pfj8"]
 [ext_resource type="PackedScene" uid="uid://bcxi0ij5k1yn" path="res://Scenes/Scene Assets/3d bolt.tscn" id="7_2ccdv"]
-[ext_resource type="PackedScene" uid="uid://dp8tkes47vcwt" path="res://Scenes/Scene Assets/User Interface.tscn" id="7_4pfj8"]
+[ext_resource type="PackedScene" uid="uid://cl4y8xdjw1w2y" path="res://Scenes/Scene Assets/User Interface.tscn" id="7_4pfj8"]
+[ext_resource type="PackedScene" uid="uid://u7xlfve1uxrm" path="res://Scenes/Game Scenes/pause_menu.tscn" id="8_2ccdv"]
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_4pfj8"]
 
@@ -503,5 +504,8 @@ texture = SubResource("ViewportTexture_aqjww")
 shape = SubResource("RectangleShape2D_g0w4n")
 
 [node name="CanvasLayer" parent="." instance=ExtResource("7_4pfj8")]
+
+[node name="PauseMenu" parent="." instance=ExtResource("8_2ccdv")]
+visible = false
 
 [editable path="Doors/Door_To_Scene_1"]

--- a/Scenes/Game Scenes/LevelTest.tscn
+++ b/Scenes/Game Scenes/LevelTest.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=28 format=4 uid="uid://cn5n77mcy1jib"]
+[gd_scene load_steps=30 format=4 uid="uid://cn5n77mcy1jib"]
 
+[ext_resource type="Script" uid="uid://c5cnabpd30qgo" path="res://Scripts/level_test.gd" id="1_76pdq"]
 [ext_resource type="Script" uid="uid://mtv4jj62dn53" path="res://Scripts/player.gd" id="1_r7f2y"]
 [ext_resource type="SpriteFrames" uid="uid://ddm0765k3wlil" path="res://Assets/2D Assets/SpriteFrames/Player_sprite_frames.tres" id="3_jirwo"]
 [ext_resource type="PackedScene" uid="uid://cixx5dbanxem1" path="res://Scenes/Scene Assets/blastershot.tscn" id="3_y8c61"]
@@ -16,6 +17,7 @@
 [ext_resource type="Script" uid="uid://c4dvbchy5m3tc" path="res://Scripts/destructible_object.gd" id="15_g414q"]
 [ext_resource type="PackedScene" uid="uid://cl4y8xdjw1w2y" path="res://Scenes/Scene Assets/User Interface.tscn" id="16_8dxgu"]
 [ext_resource type="Texture2D" uid="uid://d3758kcrsgh5s" path="res://Assets/2D Assets/Props/antenna.png" id="16_g414q"]
+[ext_resource type="PackedScene" uid="uid://u7xlfve1uxrm" path="res://Scenes/Game Scenes/pause_menu.tscn" id="18_vbmf7"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_xew73"]
 texture = ExtResource("4_nvme5")
@@ -1688,6 +1690,7 @@ size = Vector2(1.77364, 26.2927)
 height = 204.0
 
 [node name="Node2D" type="Node2D"]
+script = ExtResource("1_76pdq")
 metadata/_edit_lock_ = true
 
 [node name="Player" type="CharacterBody2D" parent="."]
@@ -1940,5 +1943,8 @@ shape = SubResource("RectangleShape2D_g414q")
 position = Vector2(5, 0)
 shape = SubResource("CapsuleShape2D_y8c61")
 debug_color = Color(0.940648, 0.168652, 0.449195, 0.42)
+
+[node name="PauseMenu" parent="." instance=ExtResource("18_vbmf7")]
+visible = false
 
 [connection signal="body_entered" from="DeathZone" to="Player" method="_on_death_zone_body_entered"]

--- a/Scenes/Game Scenes/pause_menu.tscn
+++ b/Scenes/Game Scenes/pause_menu.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=2 format=3 uid="uid://u7xlfve1uxrm"]
+
+[ext_resource type="Script" uid="uid://df1ji8s70ychp" path="res://Scripts/pause_menu.gd" id="1_h8wsg"]
+
+[node name="PauseMenu" type="CanvasLayer"]
+script = ExtResource("1_h8wsg")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+
+[node name="Resume" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Resume"
+
+[node name="Quit" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Quit"
+
+[connection signal="pressed" from="MarginContainer/VBoxContainer/Resume" to="." method="_on_resume_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/Quit" to="." method="_on_quit_pressed"]

--- a/Scripts/01_loop_start.gd
+++ b/Scripts/01_loop_start.gd
@@ -1,5 +1,7 @@
 extends Node2D
 
+@onready var pause_menu : CanvasLayer = get_node("PauseMenu")
+var paused = false
 
 func _ready() -> void:
 	pass
@@ -10,3 +12,16 @@ func _on_level_spawn(destination_tag: String):
 	var door_path = "Doors/Door_" + destination_tag
 	var door = get_node(door_path) as Door
 	NavigationManager.trigger_player_spawn(door.spawn.global_position, door.spawn_direction)
+
+func _process(delta: float) -> void:
+	if Input.is_action_just_pressed("pause"):
+		pauseMenu()
+		
+func pauseMenu() -> void:
+	if paused:
+		pause_menu.hide()
+		Engine.time_scale = 1
+	else:
+		pause_menu.show()
+		Engine.time_scale = 0
+	paused = !paused

--- a/Scripts/02_first_level.gd
+++ b/Scripts/02_first_level.gd
@@ -1,5 +1,8 @@
 extends Node2D
 
+@onready var pause_menu : CanvasLayer = get_node("PauseMenu")
+var paused = false
+
 func _ready() -> void:
 	pass
 	if NavigationManager.spawn_door_tag != null:
@@ -9,3 +12,16 @@ func _on_level_spawn(destination_tag: String):
 	var door_path = "Doors/Door_" + destination_tag
 	var door = get_node(door_path) as Door
 	NavigationManager.trigger_player_spawn(door.spawn.global_position, door.spawn_direction)
+
+func _process(delta: float) -> void:
+	if Input.is_action_just_pressed("pause"):
+		pauseMenu()
+
+func pauseMenu() -> void:
+	if paused:
+		pause_menu.hide()
+		Engine.time_scale = 1
+	else:
+		pause_menu.show()
+		Engine.time_scale = 0
+	paused = !paused

--- a/Scripts/level_test.gd
+++ b/Scripts/level_test.gd
@@ -1,0 +1,27 @@
+extends Node2D
+
+@onready var pause_menu : CanvasLayer = get_node("PauseMenu")
+var paused = false
+
+func _ready() -> void:
+	pass
+	if NavigationManager.spawn_door_tag != null:
+		_on_level_spawn(NavigationManager.spawn_door_tag)
+
+func _on_level_spawn(destination_tag: String):
+	var door_path = "Doors/Door_" + destination_tag
+	var door = get_node(door_path) as Door
+	NavigationManager.trigger_player_spawn(door.spawn.global_position, door.spawn_direction)
+
+func _process(delta: float) -> void:
+	if Input.is_action_just_pressed("pause"):
+		pauseMenu()
+
+func pauseMenu() -> void:
+	if paused:
+		pause_menu.hide()
+		Engine.time_scale = 1
+	else:
+		pause_menu.show()
+		Engine.time_scale = 0
+	paused = !paused

--- a/Scripts/level_test.gd.uid
+++ b/Scripts/level_test.gd.uid
@@ -1,0 +1,1 @@
+uid://c5cnabpd30qgo

--- a/Scripts/pause_menu.gd
+++ b/Scripts/pause_menu.gd
@@ -12,6 +12,7 @@ func _on_resume_pressed():
 func _on_quit_pressed():
 	ScoreManager.health = 100
 	ScoreManager.score = 0
+	NavigationManager.spawn_door_tag = null
 	level_root.pauseMenu()
 	get_tree().change_scene_to_file("res://Scenes/Game Scenes/00_main_menu.tscn")
 	pass

--- a/Scripts/pause_menu.gd
+++ b/Scripts/pause_menu.gd
@@ -1,0 +1,17 @@
+extends CanvasLayer
+
+@onready var level_root: Node2D = get_node("../")
+
+func _on_resume_pressed():
+	if(level_root.has_method("pauseMenu")):
+		level_root.pauseMenu()
+	else:
+		Logger.log_error("Root node of scene doesn't have a script with pausing functionality. Please see 00_loop_start.tscn & associated script for reference")
+	pass
+	
+func _on_quit_pressed():
+	ScoreManager.health = 100
+	ScoreManager.score = 0
+	level_root.pauseMenu()
+	get_tree().change_scene_to_file("res://Scenes/Game Scenes/00_main_menu.tscn")
+	pass

--- a/Scripts/pause_menu.gd.uid
+++ b/Scripts/pause_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://df1ji8s70ychp

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -286,7 +286,7 @@ func cut_jump_short () -> void:
 	timer.time_left = 0
 	
 func on_jump_buffer_timeout() -> void:
-	Logger.log_debug("Jump buffer has timed out")
+	Logger.log_debug("Jump buffer has timed out", DEBUG_OBJECT)
 	jump_buffer = false
 
 func _on_death_zone_body_entered(body: Node2D) -> void:

--- a/project.godot
+++ b/project.godot
@@ -80,6 +80,12 @@ blaster={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":2,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
+pause={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":6,"pressure":0.0,"pressed":true,"script":null)
+]
+}
 
 [rendering]
 


### PR DESCRIPTION
With this change, we've now got a pause menu on all the available scenes. In order to implement it in new scenes, the new scene has to have a root element of `Node2D` and have the following pause menu logic attached to it:
```python
@onready var pause_menu : CanvasLayer = get_node("PauseMenu")
var paused = false

func _process(delta: float) -> void:
	if Input.is_action_just_pressed("pause"):
		pauseMenu()
		
func pauseMenu() -> void:
	if paused:
		pause_menu.hide()
		Engine.time_scale = 1
	else:
		pause_menu.show()
		Engine.time_scale = 0
	paused = !paused
```