### PR TITLE
Cut 0.5.0 Release

### DIFF
--- a/Scripts/00_Logger.gd
+++ b/Scripts/00_Logger.gd
@@ -3,7 +3,7 @@ extends Node
 
 enum Level { DEBUG, INFO, WARN, ERROR, OFF }
 
-var current_level: Level = Level.DEBUG
+var current_level: Level = Level.INFO
 
 func log_debug(msg: String, class_level_debug_enabled: bool = true) -> void:
 	if current_level <= Level.DEBUG && class_level_debug_enabled:

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Project Loop"
-config/version="0.5.0-SNAPSHOT"
+config/version="0.5.0"
 run/main_scene="uid://bff7j1pbmewsu"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"


### PR DESCRIPTION
This PR bumps the project version to 0.5.0 (not -SNAPSHOT) for release. It also turns off all the logging.